### PR TITLE
Added silero-vad and two datasets for background noise

### DIFF
--- a/scripts_macos/make_features.py
+++ b/scripts_macos/make_features.py
@@ -13,10 +13,16 @@ def validate(paths):
     for p in paths:
         if not os.path.exists(p):
             raise SystemExit(f"❌ Missing directory: {p}. Run dataset prep first.")
+    print(f"✅ Validated all {len(paths)} dataset directories")
 
 
 impulse_paths = ["mit_rirs"]
-background_paths = ["fma_16k", "audioset_16k"]
+background_paths = [
+    "wham_16k",
+    "chime_16k",
+    "fma_16k",
+    "audioset_16k",
+]
 validate(impulse_paths + background_paths)
 
 # Process TTS generated samples (default)

--- a/scripts_macos/trim_silence.py
+++ b/scripts_macos/trim_silence.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Trim silence from the end of wave files using silero-vad.
+
+For wave files in personal_samples (and any subdirectories), this script:
+- Uses silero-vad to detect voice activity
+- Truncates only from the end of the file
+- Keeps only up to ~20ms of silence, with a 10ms jitter
+
+Usage:
+    python3 trim_silence.py
+"""
+
+import os
+import random
+import librosa
+import soundfile as sf
+from pathlib import Path
+from silero_vad import load_silero_vad, get_speech_timestamps
+
+
+def trim_silence(
+    input_dir: str = 'personal_samples',
+    keep_silence_duration: float = 0.020,
+    jitter_enabled: bool = True
+) -> None:
+    """
+    Trim silence from the end of all wave files in input_dir using silero-vad.
+
+    Args:
+        input_dir: Directory containing wave files (traverses subdirectories)
+        keep_silence_duration: Maximum silence to keep at the end (seconds)
+        jitter_enabled: Whether to add random jitter to the cut point
+        jitter_range: Tuple of (min_jitter, max_jitter) in seconds
+    """
+    # Load VAD model
+    vad_model = load_silero_vad()
+    print("Loaded silero-vad model")
+
+    # Walk through all files
+    processed = 0
+    for root, dirs, files in os.walk(input_dir):
+        for file in files:
+            if file.endswith('.wav'):
+                filepath = os.path.join(root, file)
+                processed += 1
+
+                # Load audio
+                y, sr = librosa.load(filepath, sr=None, mono=True)
+                audio_length = len(y) / sr
+
+                # Get speech timestamps using VAD
+                speech_timestamps = get_speech_timestamps(y, vad_model, sampling_rate=sr, return_seconds=True)
+
+                if not speech_timestamps:
+                    print(f"Warning: No speech detected in {file}, skipping")
+                    continue
+
+                # Find the actual end time of speech (end of last speech segment)
+                speech_end = speech_timestamps[-1]['end']
+
+                # Calculate how much silence is at the end
+                silence_at_end = audio_length - speech_end
+
+                # Only trim if there's more silence than we want to keep
+                if silence_at_end > keep_silence_duration:
+                    # Calculate where to cut (with ±10ms jitter)
+                    if jitter_enabled:
+                        # ±10ms jitter on the cut point relative to end of speech
+                        jitter = random.uniform(-0.010, 0.010)
+                        cut_point = speech_end + jitter
+                    else:
+                        cut_point = speech_end
+
+                    # Ensure we always keep at least keep_silence_duration at the end
+                    cut_point = max(keep_silence_duration, min(cut_point, audio_length))
+
+                    # Calculate samples to keep
+                    trim_samples = int(cut_point * sr)
+
+                    # Trim from the end
+                    y_trimmed = y[:trim_samples]
+
+                    # Save the file
+                    sf.write(filepath, y_trimmed, sr, subtype='PCM_16')
+
+                    original_duration = audio_length
+                    trimmed_duration = len(y_trimmed) / sr
+                    trim_amount = original_duration - trimmed_duration
+
+                    print(f"Processed {processed}: {filepath}")
+                    print(f"  Original: {original_duration:.3f}s")
+                    print(f"  Trimmed: {trimmed_duration:.3f}s")
+                    print(f"  Removed: {trim_amount*1000:.1f}ms ({trim_amount/silence_at_end*100:.1f}% of trailing silence)")
+                else:
+                    print(f"Skipped {processed}: {filepath}")
+                    print(f"  Trailing silence: {silence_at_end*1000:.1f}ms (≤ {keep_silence_duration*1000:.1f}ms threshold)")
+
+    print(f"\nDone! Processed {processed} files.")
+
+
+if __name__ == '__main__':
+    trim_silence()

--- a/train_microwakeword_macos.sh
+++ b/train_microwakeword_macos.sh
@@ -178,7 +178,7 @@ export DATASETS_AUDIO_BACKEND=torch
 # Other deps (best-effort)
 "$PY" -m pip install -q "git+https://github.com/puddly/pymicro-features@puddly/minimum-cpp-version" \
                            "git+https://github.com/whatsnowplaying/audio-metadata@d4ebb238e6a401bb1a5aaaac60c9e2b3cb30929f" || true
-"$PY" -m pip install -q datasets librosa scipy numpy tqdm pyyaml requests ipython jupyter || true
+"$PY" -m pip install -q datasets librosa scipy numpy tqdm pyyaml requests ipython jupyter silero-vad || true
 
 # microWakeWord source (editable)
 if [[ ! -d "micro-wake-word" ]]; then
@@ -281,16 +281,19 @@ fi
 # ── (C) pull/prepare augmentation datasets (RIR, Audioset, FMA) ──────────────
 "$PY" scripts_macos/prepare_datasets.py
 
-# ── (D) build augmenter + spectrogram feature mmaps ───────────────────────────
+# ── (D) trim silence from personal samples, if any exists
+"$PY" scripts_macos/trim_silence.py
+
+# ── (E) build augmenter + spectrogram feature mmaps ───────────────────────────
 "$PY" scripts_macos/make_features.py
 
-# ── (E) download precomputed negative spectrograms ────────────────────────────
+# ── (F) download precomputed negative spectrograms ────────────────────────────
 "$PY" scripts_macos/fetch_negatives.py
 
-# ── (F) write training YAML (tuned for your notebook) ────────────────────────
+# ── (G) write training YAML (tuned for your notebook) ────────────────────────
 "$PY" scripts_macos/write_training_yaml.py
 
-# ── (G) train + export (Metal TF) ────────────────────────────────────────────
+# ── (H) train + export (Metal TF) ────────────────────────────────────────────
 "$PY" -m microwakeword.model_train_eval \
   --training_config=training_parameters.yaml \
   --train 1 \
@@ -310,7 +313,7 @@ fi
   --first_conv_kernel_size 5 \
   --stride 2
 
-# ── (H) package artifacts (name by wake word) ─────────────────────────────────
+# ── (I) package artifacts (name by wake word) ─────────────────────────────────
 "$PY" - <<'PY'
 import os, re, shutil, json
 from pathlib import Path


### PR DESCRIPTION
silero-vad appears to be better at detecting speech, which is what we want for our wake word samples: https://github.com/wiseman/py-webrtcvad/issues/68

The VAD used in microWakeWord (py-webrtcvad, the VAD mentioned in above link) remains unchanged, we merely combine the two. We only use silero-vad to truncate from the end since the built-in recorder almost always includes some silence at the end. It should also be significantly better with noisier personal samples.

The 20ms silence at the end was suggested by Kevin Ahrendt himself, the creator of microWakeWord, in the Home Assistant Discord (the voice channel under projects). He also suggested "a small amount of jitter so [the model] doesn't lock into that alone" - therefore the -+10ms jitter implemented.

The datasets used are WHAM (as mentioned in the [microWakeWord documentation](https://github.com/OHF-Voice/micro-wake-word/blob/main/documentation/data_sources.md)) and [CHiME-home](https://ieeexplore.ieee.org/document/7336899), a dataset for in-home sound source recognition. It consists of around 6.8 hours of domestic environment audio recordings.