### PR TITLE
pinned torchaudio to TORCH_VERSION

### DIFF
--- a/train_microwakeword_macos.sh
+++ b/train_microwakeword_macos.sh
@@ -112,7 +112,7 @@ if [[ ! -f ".venv/.pinned_installed" ]]; then
     "tensorflow-metal==${TF_METAL_VERSION}"
 
   # Pinned torch stack
-  "$PY" -m pip install "torch==${TORCH_VERSION}"
+  "$PY" -m pip install "torch==${TORCH_VERSION}" "torchaudio==${TORCH_VERSION}"
 
   touch ".venv/.pinned_installed"
 else


### PR DESCRIPTION
When using the latest torchaudio with the default TORCH_VERSION of 2.9.0, the training script fails with:
Symbol not found: _torch_library_impl

This PR solves it by ensuring torch and torchaudio use the same version.