### PR TITLE
Piper voices setup fix

### DIFF
--- a/scripts_macos/get_piper_generator.sh
+++ b/scripts_macos/get_piper_generator.sh
@@ -22,9 +22,12 @@ download_file() {
 }
 
 # venv assumed active outside
-if [[ ! -d "piper-sample-generator" ]]; then
-  echo "⬇️ Cloning TaterTotterson/piper-sample-generator…"
-  git clone "$PIPER_REPO_URL" >/dev/null
+if [[ ! -d "piper-sample-generator/.git" ]]; then
+  echo "⬇️ Setting up TaterTotterson/piper-sample-generator…"
+  git init piper-sample-generator >/dev/null
+  git -C piper-sample-generator remote add origin "$PIPER_REPO_URL"
+  git -C piper-sample-generator fetch --depth=1 origin HEAD >/dev/null
+  git -C piper-sample-generator checkout -f FETCH_HEAD >/dev/null
 else
   current_origin="$(git -C piper-sample-generator remote get-url origin 2>/dev/null || true)"
   if [[ "$current_origin" != "$PIPER_REPO_URL" ]]; then

--- a/trainer_server.py
+++ b/trainer_server.py
@@ -559,7 +559,7 @@ def _catalog_voice_files(language_family: str) -> List[tuple[str, str]]:
 def _download_to_path(url: str, dest_path: Path):
     dest_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = dest_path.with_suffix(dest_path.suffix + ".tmp")
-    req = Request(url, headers={"User-Agent": "microWakeWord-Trainer/1.0"})
+    req = URLRequest(url, headers={"User-Agent": "microWakeWord-Trainer/1.0"})
     with urlopen(req, timeout=60) as resp, open(tmp_path, "wb") as out:
         shutil.copyfileobj(resp, out)
     tmp_path.replace(dest_path)


### PR DESCRIPTION
Two bug fixes for non-English wake word training:

- **trainer_server.py**: use of `URLRequest` instead of FastAPI's `Request` (which doesn't accept `headers`)
- **get_piper_generator.sh**: check for `.git/` instead of `piper-sample-generator/` directory since it might already be created by a voice download

Closes #21
Closes #22